### PR TITLE
Non-numeric value are set to Nan

### DIFF
--- a/alpyvantage/data_formating.py
+++ b/alpyvantage/data_formating.py
@@ -47,7 +47,7 @@ def _format_to_pandas(call_response, data_key, meta_data_key=None, **kwargs):
     # convert to pandas._libs.tslibs.timestamps.Timestamp
     data_pandas.index = pd.to_datetime(data_pandas.index)
     data_pandas.sort_index(inplace=True)
-    data_pandas= pd.to_numeric(data_pandas['value'], errors='coerce')
+    data_pandas= pd.to_numeric(data_pandas[data_key], errors='coerce')
     try:
         data_pandas.columns = [col.split('. ')[1]
                                for col in data_pandas.columns]

--- a/alpyvantage/data_formating.py
+++ b/alpyvantage/data_formating.py
@@ -47,7 +47,7 @@ def _format_to_pandas(call_response, data_key, meta_data_key=None, **kwargs):
     # convert to pandas._libs.tslibs.timestamps.Timestamp
     data_pandas.index = pd.to_datetime(data_pandas.index)
     data_pandas.sort_index(inplace=True)
-    data_pandas = data_pandas.astype(float, errors='ignore')
+    data_pandas= pd.to_numeric(data_pandas['value'], errors='coerce')
     try:
         data_pandas.columns = [col.split('. ')[1]
                                for col in data_pandas.columns]

--- a/alpyvantage/data_formating.py
+++ b/alpyvantage/data_formating.py
@@ -47,7 +47,8 @@ def _format_to_pandas(call_response, data_key, meta_data_key=None, **kwargs):
     # convert to pandas._libs.tslibs.timestamps.Timestamp
     data_pandas.index = pd.to_datetime(data_pandas.index)
     data_pandas.sort_index(inplace=True)
-    data_pandas= pd.to_numeric(data_pandas[data_key], errors='coerce')
+    print(data_pandas)
+    data_pandas= data_pandas.apply(pd.to_numeric, errors='coerce')
     try:
         data_pandas.columns = [col.split('. ')[1]
                                for col in data_pandas.columns]


### PR DESCRIPTION
This works better as blank responses are `'.'` which causes the current method to not parse as float, now `'.'` are converted to `NaN`. 